### PR TITLE
Remove 'tapes' from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module csmeyns.github.io/tapes
+module csmeyns.github.io
 
 go 1.19


### PR DESCRIPTION
Not sure if this works, but I see that on build, Hugo is looking for '/home/runner/work/tapes/tapes/themes'. That's one 'tapes' too many.